### PR TITLE
Return 401 when unauthorized for api routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Desktop.ini
 .DS_Store
 
 appsettings.Development.json
+.env
+.vscode/

--- a/HackerNewsCommentsFeed/Configuration/Registrations.cs
+++ b/HackerNewsCommentsFeed/Configuration/Registrations.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
@@ -72,7 +73,20 @@ public static class Registrations
                     var root = payload.RootElement;
                     context.RunClaimActions(root);
                 },
-                
+
+                OnRedirectToAuthorizationEndpoint = context => 
+                {
+                    if (context.Request.Path.ToString().Contains("api"))
+                    {
+                        context.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
+                    }
+                    else
+                    {
+                        context.Response.Redirect(context.RedirectUri);
+                    }
+
+                    return Task.CompletedTask;
+                },
             };
         });
 

--- a/HackerNewsCommentsFeed/Controllers/InterestsController.cs
+++ b/HackerNewsCommentsFeed/Controllers/InterestsController.cs
@@ -9,7 +9,7 @@ public static class InterestsController
 {
     public static IEndpointRouteBuilder MapInterestsEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/interests/{id:int}", async (
+        app.MapGet("/api/interests/{id:int}", async (
             [FromRoute] string id, 
             [FromServices] IInterestsService interestsService) =>
         {
@@ -19,7 +19,7 @@ public static class InterestsController
             
         }).RequireAuthorization().WithTags(EndpointGroupTags.Interests);
             
-        app.MapGet("/interests", async ([FromServices] IInterestsService interestsService) =>
+        app.MapGet("/api/interests", async ([FromServices] IInterestsService interestsService) =>
         {
             var interests = await interestsService.GetAllAsync();
 
@@ -27,7 +27,7 @@ public static class InterestsController
     
         }).RequireAuthorization().WithTags(EndpointGroupTags.Interests);
         
-        app.MapPost("/interests", async (
+        app.MapPost("/api/interests", async (
             [FromBody] InterestDto interest, 
             [FromServices] IInterestsService interestsService) =>
         {
@@ -37,7 +37,7 @@ public static class InterestsController
  
         }).RequireAuthorization().WithTags(EndpointGroupTags.Interests);
 
-        app.MapPut("/interests/{id}", async (
+        app.MapPut("/api/interests/{id}", async (
             [FromRoute] string id, 
             [FromBody] InterestDto interest, 
             [FromServices] IInterestsService interestsService) =>
@@ -48,7 +48,7 @@ public static class InterestsController
             
         }).RequireAuthorization().WithTags(EndpointGroupTags.Interests);
         
-        app.MapDelete("/interests/{id}", async (
+        app.MapDelete("/api/interests/{id}", async (
             [FromRoute] string id, 
             [FromServices] IInterestsService interestsService) =>
         {

--- a/HackerNewsCommentsFeed/Controllers/ItemsController.cs
+++ b/HackerNewsCommentsFeed/Controllers/ItemsController.cs
@@ -12,7 +12,7 @@ public static class ItemsController
     public static IEndpointRouteBuilder MapItemsEndpoints(this IEndpointRouteBuilder app)
     {
         
-        app.MapGet("/comments/{id:int}", async ([FromRoute] int id, [FromServices] IApiConnector apiConnector) =>
+        app.MapGet("/api/comments/{id:int}", async ([FromRoute] int id, [FromServices] IApiConnector apiConnector) =>
         {
             var item = await apiConnector.GetComment(id);
     
@@ -20,7 +20,7 @@ public static class ItemsController
             
         }).RequireAuthorization().WithTags(EndpointGroupTags.Comments);
 
-        app.MapGet("/comments/max", async ([FromServices] IApiConnector apiConnector) =>
+        app.MapGet("/api/comments/max", async ([FromServices] IApiConnector apiConnector) =>
         {
             var item = await apiConnector.GetLastComment();
 
@@ -28,7 +28,7 @@ public static class ItemsController
     
         }).RequireAuthorization().WithTags(EndpointGroupTags.Comments);
         
-        app.MapGet("/comments", async (
+        app.MapGet("/api/comments", async (
             [FromQuery] SortField? sortBy, 
             [FromQuery] SortOrder? order, 
             [FromServices] ICommentsService commentsService,
@@ -41,7 +41,7 @@ public static class ItemsController
             
         }).RequireAuthorization().WithTags(EndpointGroupTags.Comments);
 
-        app.MapPost("/comments", async ([FromBody] CommentDto comment, [FromServices] ICommentsService commentsService) =>
+        app.MapPost("/api/comments", async ([FromBody] CommentDto comment, [FromServices] ICommentsService commentsService) =>
         {
             await commentsService.AddAsync(comment);
 

--- a/HackerNewsCommentsFeed/Controllers/UsersController.cs
+++ b/HackerNewsCommentsFeed/Controllers/UsersController.cs
@@ -9,7 +9,7 @@ public static class UsersController
 {
     public static IEndpointRouteBuilder MapUsersEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/users", async ([FromServices] IUsersService usersService) =>
+        app.MapGet("/api/users", async ([FromServices] IUsersService usersService) =>
         {
             var users = await usersService.GetAllAsync();
 
@@ -17,7 +17,7 @@ public static class UsersController
             
         }).RequireAuthorization().WithTags(EndpointGroupTags.Users);
         
-        app.MapGet("/user/{email}/interests", async (
+        app.MapGet("/api/user/{email}/interests", async (
             [FromRoute] string email, 
             [FromServices] IUsersService usersService) =>
         {
@@ -27,7 +27,7 @@ public static class UsersController
             
         }).RequireAuthorization().WithTags(EndpointGroupTags.UsersInterests);
 
-        app.MapPost("/user/{email}/interests", async (
+        app.MapPost("/api/user/{email}/interests", async (
             [FromRoute] string email,
             [FromBody] InterestDto interest, 
             [FromServices] IUsersService usersService) =>
@@ -38,7 +38,7 @@ public static class UsersController
 
         }).RequireAuthorization().WithTags(EndpointGroupTags.UsersInterests);
 
-        app.MapDelete("/user/{email}/interests/{id}", async (
+        app.MapDelete("/api/user/{email}/interests/{id}", async (
             [FromRoute] string email, 
             [FromRoute] string id,
             [FromServices] IUsersService usersService) =>

--- a/Infrastructure/Mongo/Repositories/UsersRepository.cs
+++ b/Infrastructure/Mongo/Repositories/UsersRepository.cs
@@ -51,7 +51,7 @@ public class UsersRepository : IUsersRepository
         var filter = Builders<User>.Filter.Eq(u => u.Email, email);
 
         var users = await _usersCollection.FindAsync(filter);
-        var user = await users.SingleAsync();
+        var user = await users.FirstOrDefaultAsync();
 
         return user;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,11 @@
-version: '3'
+version: "3"
 services:
-  hnfeed:
-    image: ghcr.io/lvchkn/hnfeed:latest
-    ports: 
-      - "5245:5245"
-    depends_on:
-      - nginx
-      - rabbitmq
-      - mongo
-    volumes:
-      - ${PWD}/HackerNewsCommentsFeed/appsettings.Development.json:/app/appsettings.Development.json
   nginx:
     image: nginx:latest
     ports:
       - "8082:80"
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:management-alpine
     hostname: rabbitmq
     ports:
       - "5672:5672"


### PR DESCRIPTION
the idea is to have a `/login` endpoint for triggering redirection to external auth provider. `/api`-prefixed routes should just return 401 when user is unauthorized. 